### PR TITLE
improve support for ESP32

### DIFF
--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -1,0 +1,18 @@
+name: JSON check
+
+on:
+  push:
+    paths:
+      - '**.json'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "\\.json$"
+

--- a/MCP_ADC.cpp
+++ b/MCP_ADC.cpp
@@ -1,7 +1,7 @@
 //
 //    FILE: MCP_ADC.cpp
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
+// VERSION: 0.1.4
 //    DATE: 2019-10-24
 // PURPOSE: Arduino library for MCP3002, MCP3004, MCP3008, MCP3202, MCP3204, MCP3208
 //     URL: https://github.com/RobTillaart/MCP_ADC
@@ -131,7 +131,7 @@ uint8_t MCP3002::buildRequest(uint8_t channel, bool single, uint8_t * data)
 {
     // P17  fig 6.1   MCP3002 
   data[0] = 0x44;                          // start bit + MSB first bit
-  if (single) data[0] = 0x20;              // single read | differential
+  if (single) data[0] |= 0x20;             // single read | differential
   if (channel) data[0] |= (channel << 4);  // channel = 0 or 1;
   return 2;
 }

--- a/MCP_ADC.h
+++ b/MCP_ADC.h
@@ -39,7 +39,7 @@ protected:
   bool     _hwSPI;
   uint8_t  _channels;
   int16_t  _maxValue;
-  uint32_t _SPIspeed = 16000000;
+  uint32_t _SPIspeed = 1000000;   // 1MHz is a safe value (datasheet); in a test 4 MHz worked.
 
   // derived classes must implement this one
   virtual uint8_t  buildRequest(uint8_t channel, bool single, uint8_t * data) = 0;

--- a/MCP_ADC.h
+++ b/MCP_ADC.h
@@ -2,7 +2,7 @@
 //
 //    FILE: MCP_ADC.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
+// VERSION: 0.1.4
 //    DATE: 2019-10-24
 // PURPOSE: Arduino library for MCP_ADC
 //     URL: https://github.com/RobTillaart/MCP_ADC
@@ -13,7 +13,7 @@
 #include "SPI.h"
 
 
-#define MCP_ADC_LIB_VERSION       (F("0.1.3"))
+#define MCP_ADC_LIB_VERSION       (F("0.1.4"))
 
 
 class MCP_ADC

--- a/README.md
+++ b/README.md
@@ -72,12 +72,37 @@ Differential channel table
 | 7 |  7 | 6 | 3x08 |
 
 
+## About SPI Speed
+
+See https://github.com/RobTillaart/MCP_ADC/issues/3
+
+The default SPI speed is reduced to 1 MHz. 
+This is the value recommended in the datasheet for 2.7V.
+
+In a test with an ESP32 (3.3V) the library showed stable results 
+at 4 Mhz and at 6 Mhz it was almost good.
+ 
+The max value read at 6 MHz was 1020 instead of 1023  (MCP3008) 
+which indicates that the last 2 bits got lost due to signal deformation.
+
+| Proc | Voltage | safe | max  |
+|:----:|:-------:|:----:|:----:|
+| ESP32 | 2.7V |  1 MHz  | 4 Mhz |
+| UNO   | 5.0V |  2 MHz  | 4 Mhz |
+
+
+For hardware SPI the ESP32 uses the VSPI pins. (see ESP examples).
+
+
 ## Future / ideas / improvements
 
 - testing, a lot ...
-- set SPI-speed in classes directly
 - get / setF(float A, float B) => float readF(channel)   output = A*value + B;
-- analogRead (mask, int array ) read ports (set in mask) in an array in one call.
+  it actually does float mapping. As it implies the same mapping for all it might 
+  not be that useful
+- analogRead (mask, int array\[8\] ) read ports (set in mask) in an array in one call.
+- ESP32 - how to integrate the HSPI interface.
+
 
 ## Operations
 

--- a/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
+++ b/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
@@ -39,7 +39,7 @@ void setup()
   Serial.print("\t");
   Serial.println(mcp1.maxValue());
 
-  mcp1.setSPIspeed(6000000);  // seems to be the max speed. use 4MHz to be safe
+  mcp1.setSPIspeed(4000000);  // seems to be the max speed. use 1MHz (default) to be safe
 }
 
 void loop()

--- a/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
+++ b/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
@@ -38,6 +38,8 @@ void setup()
   Serial.print(mcp1.channels());
   Serial.print("\t");
   Serial.println(mcp1.maxValue());
+
+  mcp1.setSPIspeed(6000000);  // seems to be the max speed. use 4MHz to be safe
 }
 
 void loop()

--- a/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
+++ b/examples/MCP3008_analogRead_ESP32_HWSPI/MCP3008_analogRead_ESP32_HWSPI.ino
@@ -1,0 +1,59 @@
+//
+//    FILE: MCP3008_analogRead_ESP32_HWSPI.ino
+//  AUTHOR: Rob Tillaart
+// VERSION: 0.1.0
+// PURPOSE: demo
+//    DATE: 2021-03-12
+
+#include "MCP_ADC.h"
+
+
+// ESP32 PINS
+// For HSPI
+// CLK:  14
+// MOSI: 13
+// MISO: 12
+//
+// For VSPI (id = 2):
+// CLK: 18,
+// MOSI: 23,
+// MISO: 19,
+
+
+MCP3008 mcp1;                  // use HWSPI  on ESP32 (apparently VSPI)
+// MCP3008 mcp1(23, 19, 21);   // ESP32 use SWSPI  dataIn, dataOut, Clock
+// MCP3008 mcp1(6, 7, 8);      // UNO   use SWSPI  dataIn, dataOut, Clock
+
+
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println(__FILE__);
+
+  mcp1.begin(5);                // chip select pin.
+
+  Serial.println();
+  Serial.println("ADC\tCHAN\tMAXVALUE");
+  Serial.print("mcp1\t");
+  Serial.print(mcp1.channels());
+  Serial.print("\t");
+  Serial.println(mcp1.maxValue());
+}
+
+void loop()
+{
+  Serial.print(millis());
+  Serial.print("\tmcp1:\t");
+  for (int channel = 0 ; channel < mcp1.channels(); channel++)
+  {
+    uint16_t val = mcp1.analogRead(channel);
+    Serial.print(val);
+    Serial.print("\t");
+    delay(1);       // added so single reads are better visible on a scope
+  }
+  Serial.println();
+
+  delay(1000);
+}
+
+// -- END OF FILE --

--- a/examples/MCP3008_analogRead_ESP32_SWSPI/MCP3008_analogRead_ESP32_SWSPI.ino
+++ b/examples/MCP3008_analogRead_ESP32_SWSPI/MCP3008_analogRead_ESP32_SWSPI.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: MCP3008_analogRead_ESP32_SWSPI.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.1
+// VERSION: 0.1.0
 // PURPOSE: demo
 //    DATE: 2021-03-12
 

--- a/examples/MCP3008_analogRead_ESP32_SWSPI/MCP3008_analogRead_ESP32_SWSPI.ino
+++ b/examples/MCP3008_analogRead_ESP32_SWSPI/MCP3008_analogRead_ESP32_SWSPI.ino
@@ -1,0 +1,59 @@
+//
+//    FILE: MCP3008_analogRead_ESP32_SWSPI.ino
+//  AUTHOR: Rob Tillaart
+// VERSION: 0.1.1
+// PURPOSE: demo
+//    DATE: 2021-03-12
+
+#include "MCP_ADC.h"
+
+
+// ESP32 PINS
+// For HSPI
+// CLK:  14
+// MOSI: 13
+// MISO: 12
+//
+// For VSPI (id = 2):
+// CLK: 18,
+// MOSI: 23,
+// MISO: 19,
+
+
+MCP3008 mcp1(23, 19, 21);      // ESP32 use SWSPI  dataIn, dataOut, Clock
+// MCP3008 mcp1;               // use HWSPI  on ESP32 (apparently VSPI)
+// MCP3008 mcp1(6, 7, 8);      // UNO   use SWSPI  dataIn, dataOut, Clock
+
+
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println(__FILE__);
+
+  mcp1.begin(5);
+
+  Serial.println();
+  Serial.println("ADC\tCHAN\tMAXVALUE");
+  Serial.print("mcp1\t");
+  Serial.print(mcp1.channels());
+  Serial.print("\t");
+  Serial.println(mcp1.maxValue());
+}
+
+void loop()
+{
+  Serial.print(millis());
+  Serial.print("\tmcp1:\t");
+  for (int channel = 0 ; channel < mcp1.channels(); channel++)
+  {
+    uint16_t val = mcp1.analogRead(channel);
+    Serial.print(val);
+    Serial.print("\t");
+    delay(1);       // added so single reads are better visible on a scope
+  }
+  Serial.println();
+
+  delay(1000);
+}
+
+// -- END OF FILE --

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/MCP_ADC.git"
   },
-  "version":"0.1.3",
+  "version":"0.1.4",
   "frameworks": "*",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCP_ADC
-version=0.1.3
+version=0.1.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for MCP3002, MCP3004, MCP3008, MCP3202, MCP3204, MCP3208


### PR DESCRIPTION
- set default HW SPI speed to 1 MHz
- add ESP32 specific examples
- fix MCP3002 buildRequest function